### PR TITLE
Add optional API monetization module to apigw-log-analytic

### DIFF
--- a/apigw-log-analytic/README.md
+++ b/apigw-log-analytic/README.md
@@ -4,7 +4,7 @@
 
 Use these logs to populate a business intelligence service, such as [Amazon QuickSight](https://aws.amazon.com/quicksight/), to analyze and report on usage patterns across your APIs and customers.
 
-In this repo, I will show how to visualize and analyze API Gateway access logs using [Amazon QuickSight dahboard](https://docs.aws.amazon.com/quicksight/latest/user/example-create-a-dashboard.html). With this pre-built dashboard, you can analyze API usage by visualizing these components:
+In this repo, I will show how to visualize and analyze API Gateway access logs using [Amazon QuickSight dashboard](https://docs.aws.amazon.com/quicksight/latest/user/example-create-a-dashboard.html). With this pre-built dashboard, you can analyze API usage by visualizing these components:
 
 * 30 days of API usage by domain
 * API routes showing popular API paths
@@ -29,7 +29,7 @@ As we are using QuickSight for the visualization part, you have the flexibility 
 
 ## Solution Overview 
 
-The integration works by forwarding API Gateway access logs from your API Gateway to Amazon S3 bucket via [Amazon Data Firehose](https://www.google.com/search?client=firefox-b-1-d&q=Amazon+Kinesis+Data+Firehose). This solution uses the following AWS services to provide near real-time logging analytics:
+The integration works by forwarding API Gateway access logs from your API Gateway to Amazon S3 bucket via [Amazon Data Firehose](https://aws.amazon.com/firehose/). This solution uses the following AWS services to provide near real-time logging analytics:
 
 * Amazon S3 bucket ensures durable and secure storage.
 * Amazon Data Firehose is used to deliver logs into an S3 bucket.
@@ -67,6 +67,10 @@ If you have not activated QuickSight in your AWS account, follow the steps below
 
  ![Pre-requisites1](./assets/apigw-log-analytic-prerequisite2.jpg)
 
+> **Important:** Note the AWS Region where you created the QuickSight group. You must deploy the SAM template to the **same region**. QuickSight groups are regional — deploying to a different region will fail with a "principals not valid" error.
+
+> **Note:** When deploying, enter only the project name (e.g., `apiaccesslogs`), not the full group name. Do **not** include the `-Admins` suffix in the ProjectName parameter.
+
 ## Implementation
 
 Note: This solution supports the [REST API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-rest-api.html).
@@ -82,15 +86,15 @@ Once deployment is complete, configure existing API Gateway to deliver access lo
 From your local terminal, run the following commands:
 
 ```
-git clone https://github.com/aws-samples/apigw-log-analytic.git
-cd apigw-log-analytic
+git clone https://github.com/aws-samples/serverless-samples.git
+cd serverless-samples/apigw-log-analytic
 sam build
 sam deploy -g 
 ```
 
 Enter the following parameters for deployment:
 
-- Stack Name: Use it for stack name. For example, apgwaccesslogs.
+- Stack Name: Use it for stack name. For example, apigwaccesslogs.
 - ProjectName: use the project name without '-Admins'. Ensure it matches the one created in the Prerequisites section 6.
 - DataRefreshFrequency: leave as default (every 10 minutes) or customize it based on your requirement.
 
@@ -135,7 +139,7 @@ This pre-built dashboard allows you to analyze API usage by providing visualizat
 
 **Cognito based access control**
 
-If you are using [Amazon Cognito](https://aws.amazon.com/pm/cognito/?gclid=CjwKCAjw74e1BhBnEiwAbqOAjNsHPd0SoVxdGF33x27NozfK-9PWWQ2_1x62VdHIAajb2B9XUcjCzhoC8hYQAvD_BwE&trk=f5fef02c-2926-48d3-898a-b4d668742a20&sc_channel=ps&ef_id=CjwKCAjw74e1BhBnEiwAbqOAjNsHPd0SoVxdGF33x27NozfK-9PWWQ2_1x62VdHIAajb2B9XUcjCzhoC8hYQAvD_BwE:G:s&s_kwcid=AL!4422!3!651737511575!e!!g!!amazon%20cognito!19845796024!146736269189) to control access to REST APIs, this visual can help you understand which users are interacting with your APIs.
+If you are using [Amazon Cognito](https://aws.amazon.com/cognito/) to control access to REST APIs, this visual can help you understand which users are interacting with your APIs.
 
 ![dashboard overview](./assets/apigw-log-analytic-cognito.jpg)
 
@@ -157,6 +161,20 @@ This visual shows latency metrics such as response latency, integration latency,
 
 ![Latency metrics](./assets/apigw-log-analytic-latency.jpg)
 
+
+## API Monetization (Usage Reports) — Optional
+
+Once access logs are flowing, you can optionally generate per-customer usage reports for billing purposes. The [monetization module](./monetization/) is a separate add-on that queries the same access logs via Athena and applies configurable pricing plans to produce reports showing estimated charges per API key/tenant. It deploys as its own SAM stack and does not affect the core analytics pipeline.
+
+Supported pricing models:
+* **Consumption** — flat per-request rate
+* **Tiered** — volume-based rate tiers
+* **Subscription** — fixed fee with profitability analysis
+* **Freemium** — free quota with paid overage
+
+If you need usage-based billing or cost reporting, see [monetization/README.md](./monetization/README.md) for deployment instructions and details.
+
+
 ## How to open the dashboard
 
 1. Navigate to the QuickSight console.
@@ -168,12 +186,21 @@ This visual shows latency metrics such as response latency, integration latency,
 
 The SAM delete command deletes an AWS SAM application by deleting the AWS CloudFormation stack and the artifacts.
 
-Note - API Gateway access logs are retained in the S3 bucket for future reference. You may need to manually delete the bucket if necessary.
+If you deployed the monetization module, delete that stack first:
 
 ```
-cd apigw-log-analytic
+cd monetization
+sam delete
+cd ..
+```
+
+Then delete the main stack:
+
+```
 sam delete
 ```
+
+Note - API Gateway access logs are retained in the S3 bucket for future reference. You may need to manually delete the bucket if necessary.
 
 ## Conclusion
 

--- a/apigw-log-analytic/monetization/README.md
+++ b/apigw-log-analytic/monetization/README.md
@@ -1,0 +1,295 @@
+# API Monetization — Usage Reports from Access Logs
+
+This module extends the [API Gateway Log Analytics](../README.md) solution to generate per-customer usage reports that can serve as the basis for invoicing. It reads the same access logs already collected in S3 and applies configurable pricing to produce reports showing what each API consumer owes (or, for subscription customers, whether the API owner is profitable).
+
+> [!NOTE]
+> This module requires the `apigw-log-analytic` stack to be deployed first. It uses the same S3 bucket and Glue database created by that stack.
+
+## Overview
+
+The `apigw-log-analytic` solution already captures every API request: API Gateway → Firehose → S3, enriched with the customer's API key name and usage plan. This module queries that data with Athena, applies a pricing plan, generates per-customer reports, and compiles a consolidated billing file (JSON + CSV) ready for download or import into billing systems.
+
+```
+Access logs in S3 (from apigw-log-analytic stack)
+        │
+        ▼
+  Step Functions workflow (scheduled monthly or ad-hoc)
+        │
+        ├── 1. Query Athena: aggregate usage per customer
+        │
+        ├── 2. For each customer:
+        │       ├── Look up their pricing plan in DynamoDB
+        │       ├── Calculate charges based on pricing model
+        │       └── Store individual report in DynamoDB + S3
+        │
+        └── 3. Compile consolidated report
+                ├── JSON summary with all customers and line items
+                └── CSV file for spreadsheet/billing system import
+```
+
+The workflow runs automatically on the 1st of each month (configurable via the `ReportSchedule` parameter) and can also be triggered ad-hoc for any billing period. The final step produces downloadable report files in S3 and returns presigned URLs in the execution output.
+
+The connection between customers and pricing plans is through the API Gateway usage plan name. The enrichment Lambda stamps each log with the usage plan name, and each pricing plan has a `usagePlanName` field that maps to it. At report time, the customer's usage plan is matched to a pricing plan in DynamoDB.
+
+## Pricing Models
+
+Each pricing plan has a `model` field that determines how charges are calculated.
+
+### Consumption (pay-per-use)
+
+Flat rate — every request costs the same.
+
+```json
+{ "planId": "payg", "model": "consumption", "perRequestRate": 0.001, "perGbRate": 0.10 }
+```
+
+Report output: `250,000 requests × $0.001 = $250.00`
+
+### Tiered
+
+Rate drops at higher volumes.
+
+```json
+{
+  "planId": "tiered", "model": "tiered",
+  "tiers": [
+    { "upTo": 10000, "rate": 0.002 },
+    { "upTo": 100000, "rate": 0.001 },
+    { "upTo": 999999999, "rate": 0.0005 }
+  ]
+}
+```
+
+Report output: first 10K at $0.002, next 90K at $0.001, rest at $0.0005.
+
+### Subscription (profitability view)
+
+The customer pays a fixed monthly fee. The report doesn't bill them — instead it shows the API owner whether they're making money by comparing the subscription fee against estimated cost to serve.
+
+```json
+{ "planId": "pro", "model": "subscription", "baseFee": 99.00, "costPerRequest": 0.0005 }
+```
+
+Report output includes a profitability section:
+```json
+{
+  "profitability": {
+    "subscriptionFee": 99.00,
+    "estimatedCostToServe": 45.00,
+    "margin": 54.00,
+    "profitable": true
+  }
+}
+```
+
+### Freemium
+
+Free up to a quota, then overage charges apply.
+
+```json
+{ "planId": "free", "model": "freemium", "freeQuota": 10000, "overageRate": 0.003 }
+```
+
+Report output: `10,000 free + 5,000 overage × $0.003 = $15.00`
+
+## Prerequisites
+
+* [Create an AWS account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) if you do not already have one and log in. The IAM user that you use must have sufficient permissions to make necessary AWS service calls and manage AWS resources.
+* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html) installed and configured
+* [Git Installed](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+* [AWS Serverless Application Model](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html) (AWS SAM) installed
+* Python 3.13+
+* The [apigw-log-analytic](../README.md) stack deployed
+
+> [!NOTE]
+> Important: this application uses various AWS services and there are costs associated with these services after the Free Tier usage - please see the [AWS Pricing page](https://aws.amazon.com/pricing/) for details. You are responsible for any AWS costs incurred. No warranty is implied in this example.
+
+## Deployment
+
+After deploying the `apigw-log-analytic` stack, navigate to the monetization directory:
+
+```bash
+cd monetization
+```
+
+Build and deploy:
+
+```bash
+sam build
+sam deploy --guided
+```
+
+During the prompts:
+* Enter a stack name
+* Enter the desired AWS Region (must match the region where `apigw-log-analytic` is deployed)
+* **ProjectName** — Must match the ProjectName from the `apigw-log-analytic` stack
+* **AccessLogsBucketName** — S3 bucket containing API Gateway access logs (from stack output)
+* **GlueDatabaseName** — Glue database name (typically same as ProjectName)
+* **ReportSchedule** — When to generate reports (default: 1st of each month at 2am UTC)
+* Allow SAM CLI to create IAM roles with the required permissions
+
+Once you have run `sam deploy --guided` mode once and saved arguments to a configuration file (samconfig.toml), you can use `sam deploy` in future to use these defaults.
+
+Copy the API URL from the stack outputs for use in the testing section.
+
+### Load sample pricing plans
+
+Optionally, seed the DynamoDB table with sample pricing plans covering all four models:
+
+```bash
+python3 sample-plans/seed_plans.py <ProjectName>-pricing-plans --region <region>
+```
+
+## Testing
+
+To test end-to-end, you need API Gateway access logs flowing into S3 with API key data. Follow these steps in order.
+
+### 1. Set the API URL
+
+```bash
+API_URL=<ApiUrl from stack output>
+```
+
+### 2. Verify pricing plans are loaded
+
+If you ran the seed script during deployment:
+
+```bash
+curl "$API_URL/pricing"
+```
+
+You should see four plans (payg, tiered, pro-subscription, free). If not, load them:
+
+```bash
+python3 sample-plans/seed_plans.py <ProjectName>-pricing-plans --region <region>
+```
+
+### 3. Ensure access logs are flowing
+
+If you don't already have an API Gateway configured with access logging:
+
+1. Create a REST API in the API Gateway console (or use the [Example API](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-create-api-from-example.html))
+2. Create a **Usage Plan** (e.g., name it `PayAsYouGoPlan` to match the sample pricing plan)
+3. Associate the usage plan with your API stage
+4. Create an **API Key** and associate it with the usage plan
+5. Configure **Access Logging** on the stage via the API Gateway console:
+   - Go to **API Gateway** → your API → **Stages** → select your stage
+   - Click the **Logs and tracing** tab
+   - Enable **Access logging**
+   - Set the **Destination ARN** to the Firehose delivery stream ARN from the `apigw-log-analytic` stack output (`DeliveryStream`)
+   - Paste the following as the **Log format**:
+     ```
+     {"apiId":"$context.apiId","stage":"$context.stage","requestId":"$context.requestId","ip":"$context.identity.sourceIp","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","routeKey":"$context.routeKey","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength","accountId":"$context.accountId","domainName":"$context.domainName","domainPrefix":"$context.domainPrefix","errorMessage":"$context.error.message","errorResponseType":"$context.error.responseType","identityAccountId":"$context.identity.accountId","identityApiKeyId":"$context.identity.apiKeyId","identityCaller":"$context.identity.caller","identityUser":"$context.identity.user","identityUserAgent":"$context.identity.userAgent","identityUserArn":"$context.identity.userArn","path":"$context.path","resourcePath":"$context.resourcePath","integrationLatency":"$context.integration.latency","responseLatency":"$context.responseLatency"}
+     ```
+   - Click **Save**
+6. Make API requests using the API key:
+   ```bash
+   for i in {1..50}; do
+     curl -s -H "x-api-key: <your-api-key-value>" "https://<api-id>.execute-api.<region>.amazonaws.com/<stage>/your-resource" > /dev/null
+   done
+   ```
+7. Wait ~15 minutes for Firehose to flush to S3 (5 min buffer) and the Glue crawler to index the data (runs every 10 min). Verify logs landed in S3:
+   ```bash
+   aws s3 ls s3://<AccessLogsBucket>/logs/ --recursive --region <region>
+   ```
+
+> **Important:** The `usagePlanName` in your pricing plan must match the actual API Gateway usage plan name. If you used the sample plans, either name your usage plan `PayAsYouGoPlan`, or update the pricing plan:
+> ```bash
+> curl -X PUT "$API_URL/pricing/payg" -H "Content-Type: application/json" \
+>   -d '{"model":"consumption", "usagePlanName":"<YourActualUsagePlanName>", "perRequestRate":0.001, "perGbRate":0.10}'
+> ```
+
+### 4. Trigger report generation
+
+```bash
+aws stepfunctions start-execution \
+  --state-machine-arn <ReportWorkflowArn from stack output> \
+  --input '{"billingPeriod": "2025-05"}' \
+  --region <region>
+```
+
+### 5. Verify the results
+
+Check the execution status:
+
+```bash
+aws stepfunctions describe-execution \
+  --execution-arn <execution-arn-from-above> \
+  --region <region>
+```
+
+Once `"status": "SUCCEEDED"`, the output contains download URLs for the consolidated report (JSON + CSV).
+
+List generated reports via the API:
+
+```bash
+curl "$API_URL/reports"
+```
+
+Get a specific report (includes a presigned S3 download URL):
+
+```bash
+curl "$API_URL/reports/<reportId>"
+```
+
+Expected output for a customer on the consumption plan with 50 requests:
+
+```json
+{
+  "reportId": "RPT-2025-05-test-customer-1-a1b2c3d4",
+  "customerId": "test-customer-1",
+  "pricingModel": "consumption",
+  "estimatedTotal": 0.05,
+  "lineItems": [
+    { "description": "50 API requests @ $0.001/req", "quantity": 50, "unitPrice": 0.001, "amount": 0.05 }
+  ]
+}
+```
+
+### Pricing plans API reference
+
+```bash
+# Create a plan
+curl -X POST "$API_URL/pricing" -H "Content-Type: application/json" \
+  -d '{"planId":"custom", "model":"consumption", "usagePlanName":"MyPlan", "perRequestRate":0.002}'
+
+# Get a plan
+curl "$API_URL/pricing/custom"
+
+# Update a plan
+curl -X PUT "$API_URL/pricing/custom" -H "Content-Type: application/json" \
+  -d '{"model":"consumption", "usagePlanName":"MyPlan", "perRequestRate":0.003}'
+
+# Delete a plan
+curl -X DELETE "$API_URL/pricing/custom"
+```
+
+## Project Structure
+
+```
+monetization/
+├── template.yaml                  # SAM template
+├── statemachine/
+│   └── billing.asl.json           # Step Functions workflow
+├── src/
+│   ├── query_usage.py             # Athena query for per-customer usage
+│   ├── generate_report.py         # Applies pricing and creates per-customer report
+│   ├── compile_report.py          # Compiles consolidated JSON + CSV report files
+│   ├── manage_pricing.py          # Pricing plans CRUD API
+│   └── get_reports.py             # Reports retrieval API
+├── sample-plans/
+│   └── seed_plans.py              # Load sample plans into DynamoDB
+└── README.md
+```
+
+## Cleanup
+
+Delete the stack. Note that the reports S3 bucket is retained for reference and may need to be manually deleted.
+
+```bash
+sam delete
+```
+
+Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+SPDX-License-Identifier: MIT-0

--- a/apigw-log-analytic/monetization/sample-plans/seed_plans.py
+++ b/apigw-log-analytic/monetization/sample-plans/seed_plans.py
@@ -1,0 +1,77 @@
+"""
+Loads sample pricing plans into DynamoDB — one for each monetization model.
+
+Usage:
+  python seed_plans.py <table-name> [--region us-east-1]
+"""
+
+import sys
+import json
+import boto3
+from decimal import Decimal
+
+SAMPLE_PLANS = [
+    {
+        "planId": "payg",
+        "planName": "Pay-As-You-Go",
+        "model": "consumption",
+        "usagePlanName": "PayAsYouGoPlan",
+        "perRequestRate": 0.001,
+        "perGbRate": 0.10,
+    },
+    {
+        "planId": "tiered",
+        "planName": "Tiered Volume",
+        "model": "tiered",
+        "usagePlanName": "TieredPlan",
+        "tiers": [
+            {"upTo": 10000, "rate": 0.002},
+            {"upTo": 100000, "rate": 0.001},
+            {"upTo": 1000000, "rate": 0.0005},
+            {"upTo": 999999999, "rate": 0.0002},
+        ],
+        "perGbRate": 0.08,
+    },
+    {
+        "planId": "pro-subscription",
+        "planName": "Pro Subscription",
+        "model": "subscription",
+        "usagePlanName": "ProPlan",
+        "baseFee": 99.00,
+        "costPerRequest": 0.0005,
+        "perGbRate": 0.06,
+    },
+    {
+        "planId": "free",
+        "planName": "Free Tier",
+        "model": "freemium",
+        "usagePlanName": "FreePlan",
+        "freeQuota": 10000,
+        "overageRate": 0.003,
+        "perGbRate": 0,
+    },
+]
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python seed_plans.py <table-name> [--region <region>]")
+        sys.exit(1)
+
+    table_name = sys.argv[1]
+    region = "us-east-1"
+    if "--region" in sys.argv:
+        region = sys.argv[sys.argv.index("--region") + 1]
+
+    table = boto3.resource("dynamodb", region_name=region).Table(table_name)
+
+    for plan in SAMPLE_PLANS:
+        item = json.loads(json.dumps(plan), parse_float=Decimal)
+        table.put_item(Item=item)
+        print(f"  loaded: {plan['planId']} ({plan['model']})")
+
+    print(f"\n{len(SAMPLE_PLANS)} plans loaded into {table_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apigw-log-analytic/monetization/src/compile_report.py
+++ b/apigw-log-analytic/monetization/src/compile_report.py
@@ -1,0 +1,92 @@
+"""
+Compiles individual customer reports into a consolidated billing file.
+Produces both JSON and CSV formats, stored in S3 with presigned download URLs.
+
+Called as the final step in the billing workflow after all per-customer
+reports have been generated.
+"""
+
+import os
+import io
+import csv
+import json
+import boto3
+from datetime import datetime
+
+s3 = boto3.client("s3")
+
+REPORTS_BUCKET = os.environ["REPORTS_BUCKET"]
+
+
+def handler(event, context):
+    billing_period = event["billingPeriod"]
+    report_summaries = event.get("reportSummaries", [])
+
+    timestamp = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+    base_key = f"reports/{billing_period}/consolidated/billing-report-{timestamp}"
+
+    # Build consolidated data
+    consolidated = {
+        "billingPeriod": billing_period,
+        "generatedAt": datetime.utcnow().isoformat() + "Z",
+        "totalCustomers": len(report_summaries),
+        "grandTotal": round(sum(r.get("estimatedTotal", 0) for r in report_summaries), 2),
+        "currency": "USD",
+        "customers": report_summaries,
+    }
+
+    # Upload JSON
+    json_key = f"{base_key}.json"
+    s3.put_object(
+        Bucket=REPORTS_BUCKET,
+        Key=json_key,
+        Body=json.dumps(consolidated, indent=2, default=str),
+        ContentType="application/json",
+    )
+
+    # Upload CSV
+    csv_key = f"{base_key}.csv"
+    csv_body = _build_csv(report_summaries, billing_period)
+    s3.put_object(
+        Bucket=REPORTS_BUCKET,
+        Key=csv_key,
+        Body=csv_body,
+        ContentType="text/csv",
+    )
+
+    # Generate presigned download URLs (valid 1 hour)
+    json_url = s3.generate_presigned_url(
+        "get_object", Params={"Bucket": REPORTS_BUCKET, "Key": json_key}, ExpiresIn=3600
+    )
+    csv_url = s3.generate_presigned_url(
+        "get_object", Params={"Bucket": REPORTS_BUCKET, "Key": csv_key}, ExpiresIn=3600
+    )
+
+    return {
+        "billingPeriod": billing_period,
+        "totalCustomers": len(report_summaries),
+        "grandTotal": consolidated["grandTotal"],
+        "files": {
+            "json": {"bucket": REPORTS_BUCKET, "key": json_key, "downloadUrl": json_url},
+            "csv": {"bucket": REPORTS_BUCKET, "key": csv_key, "downloadUrl": csv_url},
+        },
+    }
+
+
+def _build_csv(report_summaries, billing_period):
+    """Build a CSV string from report summaries."""
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(["billing_period", "customer_id", "pricing_model", "estimated_total", "currency", "report_id"])
+
+    for r in report_summaries:
+        writer.writerow([
+            billing_period,
+            r.get("customerId", ""),
+            r.get("pricingModel", ""),
+            r.get("estimatedTotal", 0),
+            "USD",
+            r.get("reportId", ""),
+        ])
+
+    return output.getvalue()

--- a/apigw-log-analytic/monetization/src/generate_report.py
+++ b/apigw-log-analytic/monetization/src/generate_report.py
@@ -1,0 +1,229 @@
+"""
+Generates a usage report for a single API customer/tenant.
+
+Looks up the customer's pricing plan and calculates estimated charges
+based on actual API usage from access logs. The report is close enough
+to an invoice that it can be tailored into one.
+
+Supported pricing models:
+  - consumption : Pay per request at a flat rate
+  - tiered      : Rate decreases at higher volumes
+  - subscription: Fixed fee with included quota — report shows profitability
+  - freemium    : Free quota with optional paid overage
+"""
+
+import os
+import json
+import uuid
+import boto3
+from datetime import datetime
+from decimal import Decimal
+
+dynamodb = boto3.resource("dynamodb")
+s3 = boto3.client("s3")
+
+PRICING_TABLE = os.environ["PRICING_TABLE"]
+REPORTS_TABLE = os.environ["REPORTS_TABLE"]
+REPORTS_BUCKET = os.environ["REPORTS_BUCKET"]
+
+pricing_table = dynamodb.Table(PRICING_TABLE)
+reports_table = dynamodb.Table(REPORTS_TABLE)
+
+DEFAULT_PRICING = {
+    "planId": "default",
+    "planName": "Pay-As-You-Go",
+    "model": "consumption",
+    "perRequestRate": 0.001,
+    "perGbRate": 0.10,
+}
+
+
+def handler(event, context):
+    customer = event["customer"]
+    billing_period = event["billingPeriod"]
+    customer_id = customer["customerId"]
+    usage_plan = customer.get("usagePlan", "default")
+
+    pricing = _get_pricing(usage_plan)
+    model = pricing.get("model", "consumption")
+
+    # Calculate charges based on the pricing model
+    if model == "tiered":
+        line_items = _calc_tiered(pricing, customer)
+    elif model == "subscription":
+        line_items = _calc_subscription(pricing, customer)
+    elif model == "freemium":
+        line_items = _calc_freemium(pricing, customer)
+    else:
+        line_items = _calc_consumption(pricing, customer)
+
+    # Add data transfer if configured
+    line_items += _calc_data_transfer(pricing, customer)
+
+    estimated_total = round(sum(item["amount"] for item in line_items), 2)
+
+    report = {
+        "reportId": f"RPT-{billing_period}-{customer_id}-{uuid.uuid4().hex[:8]}",
+        "customerId": customer_id,
+        "apiKeyId": customer.get("apiKeyId", ""),
+        "usagePlan": usage_plan,
+        "billingPeriod": billing_period,
+        "generatedAt": datetime.utcnow().isoformat() + "Z",
+        "pricingModel": model,
+        "pricingPlan": pricing.get("planName", pricing["planId"]),
+        "usage": {
+            "totalRequests": customer["totalRequests"],
+            "successfulRequests": customer["totalSuccessful"],
+            "errorRequests": customer["totalErrors"],
+            "totalResponseBytes": customer["totalResponseBytes"],
+            "routes": customer.get("routes", []),
+        },
+        "lineItems": line_items,
+        "estimatedTotal": estimated_total,
+        "currency": "USD",
+    }
+
+    # For subscription model, add profitability section
+    if model == "subscription":
+        base_fee = float(pricing.get("baseFee", 0))
+        report["profitability"] = {
+            "subscriptionFee": base_fee,
+            "estimatedCostToServe": estimated_total,
+            "margin": round(base_fee - estimated_total, 2),
+            "profitable": base_fee >= estimated_total,
+        }
+
+    # Store report
+    _store_report(report)
+
+    s3_key = f"reports/{billing_period}/{customer_id}/{report['reportId']}.json"
+    s3.put_object(
+        Bucket=REPORTS_BUCKET,
+        Key=s3_key,
+        Body=json.dumps(report, indent=2, default=str),
+        ContentType="application/json",
+    )
+
+    return {
+        "reportId": report["reportId"],
+        "customerId": customer_id,
+        "pricingModel": model,
+        "estimatedTotal": estimated_total,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Pricing model calculations
+# ---------------------------------------------------------------------------
+
+def _calc_consumption(pricing, customer):
+    """Flat rate per request."""
+    rate = float(pricing.get("perRequestRate", 0.001))
+    reqs = customer["totalRequests"]
+    return [{
+        "description": f"{reqs:,} API requests @ ${rate}/req",
+        "quantity": reqs,
+        "unitPrice": rate,
+        "amount": round(reqs * rate, 2),
+    }]
+
+
+def _calc_tiered(pricing, customer):
+    """Volume tiers — rate drops at higher usage."""
+    items = []
+    remaining = customer["totalRequests"]
+    prev = 0
+    for tier in sorted(pricing.get("tiers", []), key=lambda t: int(t["upTo"])):
+        up_to = int(tier["upTo"])
+        rate = float(tier["rate"])
+        tier_size = up_to - prev
+        qty = min(remaining, tier_size)
+        if qty <= 0:
+            break
+        items.append({
+            "description": f"Requests {prev + 1:,}–{prev + qty:,} @ ${rate}/req",
+            "quantity": qty,
+            "unitPrice": rate,
+            "amount": round(qty * rate, 2),
+        })
+        remaining -= qty
+        prev = up_to
+    return items
+
+
+def _calc_subscription(pricing, customer):
+    """
+    Subscription reports show cost-to-serve, not a bill.
+    The API owner pays a flat fee — this shows whether they're profitable.
+    """
+    # Estimate what it would cost at a per-request rate
+    cost_rate = float(pricing.get("costPerRequest", 0.0005))
+    reqs = customer["totalRequests"]
+    return [{
+        "description": f"Estimated cost to serve {reqs:,} requests @ ${cost_rate}/req",
+        "quantity": reqs,
+        "unitPrice": cost_rate,
+        "amount": round(reqs * cost_rate, 2),
+    }]
+
+
+def _calc_freemium(pricing, customer):
+    """Free quota, then paid overage."""
+    items = []
+    free_quota = int(pricing.get("freeQuota", 10000))
+    reqs = customer["totalRequests"]
+    free_used = min(reqs, free_quota)
+
+    items.append({
+        "description": f"Free tier: {free_used:,} of {free_quota:,} requests",
+        "quantity": free_used,
+        "unitPrice": 0,
+        "amount": 0,
+    })
+
+    overage = max(0, reqs - free_quota)
+    if overage > 0:
+        rate = float(pricing.get("overageRate", 0.002))
+        items.append({
+            "description": f"Overage: {overage:,} requests @ ${rate}/req",
+            "quantity": overage,
+            "unitPrice": rate,
+            "amount": round(overage * rate, 2),
+        })
+    return items
+
+
+def _calc_data_transfer(pricing, customer):
+    """Data transfer charge (shared across all models)."""
+    gb_rate = float(pricing.get("perGbRate", 0))
+    total_gb = customer["totalResponseBytes"] / (1024 ** 3)
+    if total_gb > 0 and gb_rate > 0:
+        return [{
+            "description": f"Data transfer: {total_gb:.4f} GB @ ${gb_rate}/GB",
+            "quantity": round(total_gb, 6),
+            "unitPrice": gb_rate,
+            "amount": round(total_gb * gb_rate, 2),
+        }]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_pricing(usage_plan):
+    resp = pricing_table.get_item(Key={"planId": usage_plan})
+    if "Item" in resp:
+        return resp["Item"]
+    scan = pricing_table.scan(
+        FilterExpression="usagePlanName = :up",
+        ExpressionAttributeValues={":up": usage_plan},
+    )
+    if scan["Items"]:
+        return scan["Items"][0]
+    return DEFAULT_PRICING
+
+
+def _store_report(report):
+    item = json.loads(json.dumps(report, default=str), parse_float=Decimal)
+    reports_table.put_item(Item=item)

--- a/apigw-log-analytic/monetization/src/get_reports.py
+++ b/apigw-log-analytic/monetization/src/get_reports.py
@@ -1,0 +1,96 @@
+"""
+API for retrieving usage reports. Supports listing reports,
+filtering by customer/period, and fetching a single report.
+"""
+
+import os
+import json
+import boto3
+from decimal import Decimal
+
+dynamodb = boto3.resource("dynamodb")
+s3 = boto3.client("s3")
+
+REPORTS_TABLE = os.environ["REPORTS_TABLE"]
+REPORTS_BUCKET = os.environ["REPORTS_BUCKET"]
+
+table = dynamodb.Table(REPORTS_TABLE)
+
+
+def handler(event, context):
+    path_params = event.get("pathParameters") or {}
+    query_params = event.get("queryStringParameters") or {}
+    report_id = path_params.get("reportId")
+
+    if report_id:
+        return _get_report(report_id)
+    return _list_reports(query_params)
+
+
+def _list_reports(query_params):
+    customer_id = query_params.get("customerId")
+    billing_period = query_params.get("billingPeriod")
+
+    if customer_id:
+        key_expr = "customerId = :cid"
+        values = {":cid": customer_id}
+        if billing_period:
+            key_expr += " AND billingPeriod = :bp"
+            values[":bp"] = billing_period
+        result = table.query(
+            IndexName="customer-period-index",
+            KeyConditionExpression=key_expr,
+            ExpressionAttributeValues=values,
+        )
+    else:
+        result = table.scan()
+
+    items = _decimals(result.get("Items", []))
+    summaries = [{
+        "reportId": r["reportId"],
+        "customerId": r["customerId"],
+        "billingPeriod": r["billingPeriod"],
+        "pricingModel": r.get("pricingModel", ""),
+        "estimatedTotal": r.get("estimatedTotal", 0),
+        "totalRequests": r.get("usage", {}).get("totalRequests", 0),
+        "generatedAt": r.get("generatedAt", ""),
+    } for r in items]
+
+    return _response(200, {"reports": summaries})
+
+
+def _get_report(report_id):
+    result = table.get_item(Key={"reportId": report_id})
+    if "Item" not in result:
+        return _response(404, {"error": f"Report '{report_id}' not found"})
+
+    report = _decimals(result["Item"])
+    s3_key = f"reports/{report['billingPeriod']}/{report['customerId']}/{report_id}.json"
+    try:
+        report["downloadUrl"] = s3.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": REPORTS_BUCKET, "Key": s3_key},
+            ExpiresIn=3600,
+        )
+    except Exception:
+        report["downloadUrl"] = None
+
+    return _response(200, report)
+
+
+def _response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
+        "body": json.dumps(body, default=str),
+    }
+
+
+def _decimals(obj):
+    if isinstance(obj, list):
+        return [_decimals(i) for i in obj]
+    if isinstance(obj, dict):
+        return {k: _decimals(v) for k, v in obj.items()}
+    if isinstance(obj, Decimal):
+        return float(obj)
+    return obj

--- a/apigw-log-analytic/monetization/src/manage_pricing.py
+++ b/apigw-log-analytic/monetization/src/manage_pricing.py
@@ -1,0 +1,94 @@
+"""
+CRUD API for managing pricing plans.
+
+Each plan has a "model" field that determines how usage is calculated:
+  - consumption  : flat per-request rate
+  - tiered       : volume-based tiers
+  - subscription : fixed fee (report shows profitability)
+  - freemium     : free quota with paid overage
+"""
+
+import os
+import json
+import boto3
+from decimal import Decimal
+
+dynamodb = boto3.resource("dynamodb")
+table = dynamodb.Table(os.environ["PRICING_TABLE"])
+
+
+def handler(event, context):
+    method = event["httpMethod"]
+    path_params = event.get("pathParameters") or {}
+    plan_id = path_params.get("planId")
+
+    if method == "GET" and not plan_id:
+        return _list_plans()
+    elif method == "GET" and plan_id:
+        return _get_plan(plan_id)
+    elif method == "POST":
+        return _create_plan(event)
+    elif method == "PUT" and plan_id:
+        return _update_plan(plan_id, event)
+    elif method == "DELETE" and plan_id:
+        return _delete_plan(plan_id)
+    else:
+        return _response(405, {"error": "Method not allowed"})
+
+
+def _list_plans():
+    items = table.scan().get("Items", [])
+    return _response(200, {"plans": _decimals(items)})
+
+
+def _get_plan(plan_id):
+    result = table.get_item(Key={"planId": plan_id})
+    if "Item" not in result:
+        return _response(404, {"error": f"Plan '{plan_id}' not found"})
+    return _response(200, _decimals(result["Item"]))
+
+
+def _create_plan(event):
+    body = json.loads(event["body"])
+    if "planId" not in body:
+        return _response(400, {"error": "planId is required"})
+    existing = table.get_item(Key={"planId": body["planId"]})
+    if "Item" in existing:
+        return _response(409, {"error": f"Plan '{body['planId']}' already exists"})
+    item = json.loads(json.dumps(body), parse_float=Decimal)
+    table.put_item(Item=item)
+    return _response(201, body)
+
+
+def _update_plan(plan_id, event):
+    existing = table.get_item(Key={"planId": plan_id})
+    if "Item" not in existing:
+        return _response(404, {"error": f"Plan '{plan_id}' not found"})
+    body = json.loads(event["body"])
+    body["planId"] = plan_id
+    item = json.loads(json.dumps(body), parse_float=Decimal)
+    table.put_item(Item=item)
+    return _response(200, body)
+
+
+def _delete_plan(plan_id):
+    table.delete_item(Key={"planId": plan_id})
+    return _response(200, {"message": f"Plan '{plan_id}' deleted"})
+
+
+def _response(status_code, body):
+    return {
+        "statusCode": status_code,
+        "headers": {"Content-Type": "application/json", "Access-Control-Allow-Origin": "*"},
+        "body": json.dumps(body, default=str),
+    }
+
+
+def _decimals(obj):
+    if isinstance(obj, list):
+        return [_decimals(i) for i in obj]
+    if isinstance(obj, dict):
+        return {k: _decimals(v) for k, v in obj.items()}
+    if isinstance(obj, Decimal):
+        return float(obj)
+    return obj

--- a/apigw-log-analytic/monetization/src/query_usage.py
+++ b/apigw-log-analytic/monetization/src/query_usage.py
@@ -1,0 +1,137 @@
+"""
+Queries API Gateway access logs via Athena to aggregate usage per
+customer (API key) for a billing period. Returns per-customer usage
+broken down by route, method, and status code.
+"""
+
+import os
+import time
+import boto3
+from datetime import datetime, timedelta
+
+athena = boto3.client("athena")
+
+GLUE_DATABASE = os.environ["GLUE_DATABASE"]
+PROJECT_NAME = os.environ["PROJECT_NAME"]
+ACCESS_LOGS_BUCKET = os.environ["ACCESS_LOGS_BUCKET"]
+
+ATHENA_OUTPUT = f"s3://{PROJECT_NAME}-athena-results-{boto3.client('sts').get_caller_identity()['Account']}/"
+
+
+def handler(event, context):
+    billing_period = _resolve_billing_period(event)
+    year, month = billing_period.split("-")
+
+    query = f"""
+        SELECT
+            "identity.apikeyname" AS customer_name,
+            identityapikeyid       AS api_key_id,
+            "identity.usageplanname" AS usage_plan,
+            routekey               AS route,
+            httpmethod             AS method,
+            status,
+            COUNT(*)               AS request_count,
+            AVG(CAST(responselatency AS double))  AS avg_latency_ms,
+            SUM(CAST(responselength AS bigint))   AS total_response_bytes
+        FROM logs
+        WHERE year = '{year}' AND month = '{month}'
+          AND "identity.apikeyname" != '-'
+          AND status IS NOT NULL
+        GROUP BY
+            "identity.apikeyname",
+            identityapikeyid,
+            "identity.usageplanname",
+            routekey,
+            httpmethod,
+            status
+        ORDER BY customer_name, request_count DESC
+    """
+
+    execution_id = _run_query(query)
+    rows = _get_results(execution_id)
+    customers = _aggregate(rows, billing_period)
+
+    return {"customers": customers, "billingPeriod": billing_period}
+
+
+def _resolve_billing_period(event):
+    if "billingPeriod" in event:
+        return event["billingPeriod"]
+    first = datetime.utcnow().replace(day=1)
+    prev = first - timedelta(days=1)
+    return prev.strftime("%Y-%m")
+
+
+def _run_query(query):
+    resp = athena.start_query_execution(
+        QueryString=query,
+        QueryExecutionContext={"Database": GLUE_DATABASE},
+        ResultConfiguration={"OutputLocation": ATHENA_OUTPUT},
+    )
+    return resp["QueryExecutionId"]
+
+
+def _get_results(execution_id, max_wait=120):
+    elapsed = 0
+    while elapsed < max_wait:
+        resp = athena.get_query_execution(QueryExecutionId=execution_id)
+        state = resp["QueryExecution"]["Status"]["State"]
+        if state == "SUCCEEDED":
+            break
+        if state in ("FAILED", "CANCELLED"):
+            reason = resp["QueryExecution"]["Status"].get("StateChangeReason", "Unknown")
+            raise RuntimeError(f"Athena query {state}: {reason}")
+        time.sleep(2)
+        elapsed += 2
+
+    rows = []
+    paginator = athena.get_paginator("get_query_results")
+    for page in paginator.paginate(QueryExecutionId=execution_id):
+        for row in page["ResultSet"]["Rows"]:
+            rows.append([col.get("VarCharValue", "") for col in row["Data"]])
+    return rows
+
+
+def _aggregate(rows, billing_period):
+    if len(rows) <= 1:
+        return []
+
+    header = rows[0]
+    customers = {}
+
+    for row in rows[1:]:
+        rec = dict(zip(header, row))
+        name = rec["customer_name"]
+        if name not in customers:
+            customers[name] = {
+                "customerId": name,
+                "apiKeyId": rec["api_key_id"],
+                "usagePlan": rec["usage_plan"],
+                "billingPeriod": billing_period,
+                "routes": [],
+                "totalRequests": 0,
+                "totalSuccessful": 0,
+                "totalErrors": 0,
+                "totalResponseBytes": 0,
+            }
+
+        count = int(rec["request_count"])
+        status = int(rec["status"]) if rec["status"] else 0
+        resp_bytes = int(rec["total_response_bytes"]) if rec["total_response_bytes"] else 0
+
+        customers[name]["routes"].append({
+            "route": rec["route"],
+            "method": rec["method"],
+            "status": rec["status"],
+            "requestCount": count,
+            "avgLatencyMs": round(float(rec["avg_latency_ms"]), 2) if rec["avg_latency_ms"] else 0,
+            "totalResponseBytes": resp_bytes,
+        })
+        customers[name]["totalRequests"] += count
+        customers[name]["totalResponseBytes"] += resp_bytes
+        if 200 <= status < 400:
+            customers[name]["totalSuccessful"] += count
+        else:
+            customers[name]["totalErrors"] += count
+
+    return list(customers.values())

--- a/apigw-log-analytic/monetization/statemachine/billing.asl.json
+++ b/apigw-log-analytic/monetization/statemachine/billing.asl.json
@@ -1,0 +1,109 @@
+{
+  "Comment": "Queries API usage from Athena, generates per-customer reports, and compiles a consolidated billing file",
+  "StartAt": "QueryUsage",
+  "States": {
+    "QueryUsage": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${QueryUsageFunctionArn}",
+        "Payload.$": "$"
+      },
+      "ResultPath": "$.usageData",
+      "ResultSelector": {
+        "customers.$": "$.Payload.customers",
+        "billingPeriod.$": "$.Payload.billingPeriod"
+      },
+      "Next": "HasCustomers",
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "IntervalSeconds": 30,
+          "MaxAttempts": 2,
+          "BackoffRate": 2
+        }
+      ]
+    },
+    "HasCustomers": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.usageData.customers[0]",
+          "IsPresent": true,
+          "Next": "GenerateReports"
+        }
+      ],
+      "Default": "NoUsageFound"
+    },
+    "GenerateReports": {
+      "Type": "Map",
+      "ItemsPath": "$.usageData.customers",
+      "Parameters": {
+        "customer.$": "$$.Map.Item.Value",
+        "billingPeriod.$": "$.usageData.billingPeriod"
+      },
+      "ResultPath": "$.reportSummaries",
+      "MaxConcurrency": 5,
+      "Iterator": {
+        "StartAt": "GenerateReport",
+        "States": {
+          "GenerateReport": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "Parameters": {
+              "FunctionName": "${GenerateReportFunctionArn}",
+              "Payload.$": "$"
+            },
+            "ResultSelector": {
+              "reportId.$": "$.Payload.reportId",
+              "customerId.$": "$.Payload.customerId",
+              "pricingModel.$": "$.Payload.pricingModel",
+              "estimatedTotal.$": "$.Payload.estimatedTotal"
+            },
+            "End": true,
+            "Retry": [
+              {
+                "ErrorEquals": ["States.TaskFailed"],
+                "IntervalSeconds": 10,
+                "MaxAttempts": 2,
+                "BackoffRate": 2
+              }
+            ]
+          }
+        }
+      },
+      "Next": "CompileReport"
+    },
+    "CompileReport": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${CompileReportFunctionArn}",
+        "Payload": {
+          "billingPeriod.$": "$.usageData.billingPeriod",
+          "reportSummaries.$": "$.reportSummaries"
+        }
+      },
+      "ResultSelector": {
+        "billingPeriod.$": "$.Payload.billingPeriod",
+        "totalCustomers.$": "$.Payload.totalCustomers",
+        "grandTotal.$": "$.Payload.grandTotal",
+        "files.$": "$.Payload.files"
+      },
+      "End": true,
+      "Retry": [
+        {
+          "ErrorEquals": ["States.TaskFailed"],
+          "IntervalSeconds": 10,
+          "MaxAttempts": 2,
+          "BackoffRate": 2
+        }
+      ]
+    },
+    "NoUsageFound": {
+      "Type": "Pass",
+      "Result": { "message": "No customer usage found for this period" },
+      "End": true
+    }
+  }
+}

--- a/apigw-log-analytic/monetization/template.yaml
+++ b/apigw-log-analytic/monetization/template.yaml
@@ -1,0 +1,285 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  API monetization — generates per-customer usage reports from API Gateway
+  access logs, supporting consumption, tiered, subscription, and freemium
+  pricing models.
+
+Parameters:
+  ProjectName:
+    Type: String
+    Description: Must match the ProjectName from the parent apigw-log-analytic stack
+  AccessLogsBucketName:
+    Type: String
+    Description: S3 bucket containing API Gateway access logs (from parent stack)
+  GlueDatabaseName:
+    Type: String
+    Description: Glue database name (typically same as ProjectName)
+  ReportSchedule:
+    Type: String
+    Default: "cron(0 2 1 * ? *)"
+    Description: When to generate reports (default is 1st of each month at 2am UTC)
+
+Globals:
+  Function:
+    Runtime: python3.13
+    MemorySize: 256
+    Timeout: 300
+    Environment:
+      Variables:
+        PRICING_TABLE: !Ref PricingPlansTable
+        REPORTS_TABLE: !Ref ReportsTable
+        REPORTS_BUCKET: !Ref ReportsBucket
+        GLUE_DATABASE: !Ref GlueDatabaseName
+        ACCESS_LOGS_BUCKET: !Ref AccessLogsBucketName
+        PROJECT_NAME: !Ref ProjectName
+
+Resources:
+  # ---- Storage ----
+  PricingPlansTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub "${ProjectName}-pricing-plans"
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: planId
+          AttributeType: S
+      KeySchema:
+        - AttributeName: planId
+          KeyType: HASH
+
+  ReportsTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      TableName: !Sub "${ProjectName}-reports"
+      BillingMode: PAY_PER_REQUEST
+      AttributeDefinitions:
+        - AttributeName: reportId
+          AttributeType: S
+        - AttributeName: customerId
+          AttributeType: S
+        - AttributeName: billingPeriod
+          AttributeType: S
+      KeySchema:
+        - AttributeName: reportId
+          KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: customer-period-index
+          KeySchema:
+            - AttributeName: customerId
+              KeyType: HASH
+            - AttributeName: billingPeriod
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+
+  ReportsBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub "${ProjectName}-reports-${AWS::AccountId}"
+
+  AthenaResultsBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      BucketName: !Sub "${ProjectName}-athena-results-${AWS::AccountId}"
+      LifecycleConfiguration:
+        Rules:
+          - Id: CleanupQueryResults
+            Status: Enabled
+            ExpirationInDays: 7
+
+  # ---- Lambda Functions ----
+  QueryUsageFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: query_usage.handler
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - athena:StartQueryExecution
+                - athena:GetQueryExecution
+                - athena:GetQueryResults
+              Resource: "*"
+            - Effect: Allow
+              Action:
+                - glue:GetTable
+                - glue:GetDatabase
+                - glue:GetPartitions
+              Resource: "*"
+            - Effect: Allow
+              Action:
+                - s3:GetObject
+                - s3:ListBucket
+                - s3:GetBucketLocation
+                - s3:PutObject
+              Resource:
+                - !Sub "arn:aws:s3:::${AccessLogsBucketName}"
+                - !Sub "arn:aws:s3:::${AccessLogsBucketName}/*"
+                - !Sub "arn:aws:s3:::${ProjectName}-athena-results-${AWS::AccountId}"
+                - !Sub "arn:aws:s3:::${ProjectName}-athena-results-${AWS::AccountId}/*"
+
+  GenerateReportFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: generate_report.handler
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:PutItem
+                - dynamodb:GetItem
+                - dynamodb:Scan
+              Resource:
+                - !GetAtt ReportsTable.Arn
+                - !GetAtt PricingPlansTable.Arn
+            - Effect: Allow
+              Action:
+                - s3:PutObject
+              Resource:
+                - !Sub "arn:aws:s3:::${ProjectName}-reports-${AWS::AccountId}/*"
+
+  CompileReportFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: compile_report.handler
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+              Resource:
+                - !GetAtt ReportsTable.Arn
+            - Effect: Allow
+              Action:
+                - s3:PutObject
+                - s3:GetObject
+              Resource:
+                - !Sub "arn:aws:s3:::${ProjectName}-reports-${AWS::AccountId}/*"
+
+  ManagePricingFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: manage_pricing.handler
+      Events:
+        GetPlans:
+          Type: Api
+          Properties:
+            Path: /pricing
+            Method: GET
+        CreatePlan:
+          Type: Api
+          Properties:
+            Path: /pricing
+            Method: POST
+        GetPlan:
+          Type: Api
+          Properties:
+            Path: /pricing/{planId}
+            Method: GET
+        UpdatePlan:
+          Type: Api
+          Properties:
+            Path: /pricing/{planId}
+            Method: PUT
+        DeletePlan:
+          Type: Api
+          Properties:
+            Path: /pricing/{planId}
+            Method: DELETE
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:PutItem
+                - dynamodb:GetItem
+                - dynamodb:Scan
+                - dynamodb:UpdateItem
+                - dynamodb:DeleteItem
+              Resource:
+                - !GetAtt PricingPlansTable.Arn
+
+  GetReportsFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: src/
+      Handler: get_reports.handler
+      Events:
+        ListReports:
+          Type: Api
+          Properties:
+            Path: /reports
+            Method: GET
+        GetReport:
+          Type: Api
+          Properties:
+            Path: /reports/{reportId}
+            Method: GET
+      Policies:
+        - AWSLambdaBasicExecutionRole
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:Query
+                - dynamodb:Scan
+              Resource:
+                - !GetAtt ReportsTable.Arn
+                - !Sub "${ReportsTable.Arn}/index/*"
+            - Effect: Allow
+              Action:
+                - s3:GetObject
+              Resource:
+                - !Sub "arn:aws:s3:::${ProjectName}-reports-${AWS::AccountId}/*"
+
+  # ---- Step Functions Workflow ----
+  ReportWorkflow:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      Name: !Sub "${ProjectName}-report-workflow"
+      DefinitionUri: statemachine/billing.asl.json
+      DefinitionSubstitutions:
+        QueryUsageFunctionArn: !GetAtt QueryUsageFunction.Arn
+        GenerateReportFunctionArn: !GetAtt GenerateReportFunction.Arn
+        CompileReportFunctionArn: !GetAtt CompileReportFunction.Arn
+      Events:
+        Schedule:
+          Type: Schedule
+          Properties:
+            Schedule: !Ref ReportSchedule
+            Enabled: true
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref QueryUsageFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref GenerateReportFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref CompileReportFunction
+
+Outputs:
+  ApiUrl:
+    Description: API endpoint for pricing plans and reports
+    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod"
+  ReportsBucket:
+    Description: S3 bucket storing generated reports
+    Value: !Ref ReportsBucket
+  ReportWorkflowArn:
+    Description: Step Functions workflow ARN (for manual triggers)
+    Value: !Ref ReportWorkflow


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds a `monetization/` module that generates per-customer usage reports from the existing API Gateway access logs in S3. Deploys as a separate SAM stack — does not modify the parent analytics pipeline.

Supports consumption, tiered, subscription, and freemium pricing models. Reports are produced as JSON + CSV via a Step Functions workflow (monthly schedule or ad-hoc).

## Changes

- New `monetization/` folder (SAM template, Step Functions workflow, 5 Lambda handlers, sample plans, README)
- Updated root `README.md`: added monetization section (marked optional), fixed typos, corrected links, added cleanup instructions for the child stack

## How it works

Existing access logs in S3 → Athena query (per-customer aggregation) → pricing plan lookup in DynamoDB → per-customer report → consolidated JSON + CSV in S3

Also includes a REST API for managing pricing plans and browsing reports.

## Testing

- Python source validated (no syntax errors)
- SAM template and ASL JSON validated
- README links verified against file structure
- No build artifacts or local config included


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice with credits given to me.
